### PR TITLE
fix for varnish 4.1.1

### DIFF
--- a/src/vmod_geoip.c
+++ b/src/vmod_geoip.c
@@ -3,6 +3,7 @@
 #include <GeoIP.h>
 #include <GeoIPCity.h>
 
+#include "vcl.h"
 #include "vrt.h"
 #include "cache/cache.h"
 #include "vcc_if.h"
@@ -60,9 +61,12 @@ static void free_databases(void* ptr)
     free(ptr);
 }
 
-int
-init_function(struct vmod_priv *pp, const struct VCL_conf *conf)
+int __match_proto__(vmod_init_f)
+event_function(VRT_CTX, struct vmod_priv *pp, enum vcl_event_e e)
 {
+    if (e != VCL_EVENT_LOAD)
+        return 0;
+
     pp->priv = malloc(sizeof(struct GeoIP_databases));
     if (!pp->priv)
         return 1;

--- a/src/vmod_geoip.vcc
+++ b/src/vmod_geoip.vcc
@@ -1,5 +1,5 @@
 $Module geoip Varnish GeoIP Module
-$Init init_function
+$Event event_function
 $Function STRING country(PRIV_VCL, STRING)
 $Function STRING country_code(PRIV_VCL, STRING)
 $Function STRING country_code_from_ip(PRIV_VCL, IP)


### PR DESCRIPTION
Hi,

We're using this module for our Varnish setup and found that it didn't compile for Varnish v4.1.1. Here's a small patch to make that work.
